### PR TITLE
Add Linux ARM64 support and Dawn X11/Wayland surface configuration

### DIFF
--- a/.github/workflows/build-skia.yml
+++ b/.github/workflows/build-skia.yml
@@ -18,33 +18,51 @@ jobs:
           - os: ubuntu-latest
             platform: wasm
             variant: cpu
+            arch: ""
           - os: ubuntu-latest
             platform: wasm
             variant: gpu
-          - os: ubuntu-latest
+            arch: ""
+          - os: ubuntu-24.04
             platform: linux
             variant: cpu
-          - os: ubuntu-latest
+            arch: x64
+          - os: ubuntu-24.04
             platform: linux
             variant: gpu
+            arch: x64
+          - os: ubuntu-24.04-arm
+            platform: linux
+            variant: cpu
+            arch: arm64
+          - os: ubuntu-24.04-arm
+            platform: linux
+            variant: gpu
+            arch: arm64
           - os: macos-latest
             platform: mac
             variant: cpu
+            arch: ""
           - os: macos-latest
             platform: mac
             variant: gpu
+            arch: ""
           - os: macos-latest
             platform: ios
             variant: cpu
+            arch: ""
           - os: macos-latest
             platform: ios
             variant: gpu
+            arch: ""
           - os: windows-latest
             platform: win
             variant: cpu
+            arch: ""
           - os: windows-latest
             platform: win
             variant: gpu
+            arch: ""
     runs-on: ${{ matrix.os }}
     env:
       SKIA_BRANCH: chrome/m144
@@ -99,8 +117,22 @@ jobs:
       - name: Build Skia (Release)
         if: ${{ !inputs.test_mode }}
         run: |
-          python3 build-skia.py ${{ matrix.platform }} -variant ${{ matrix.variant }} -config Release --shallow -branch ${{ env.SKIA_BRANCH }}
+          ARCH_ARG=""
+          if [ -n "${{ matrix.arch }}" ]; then
+            ARCH_ARG="-archs ${{ matrix.arch }}"
+          fi
+          python3 build-skia.py ${{ matrix.platform }} -variant ${{ matrix.variant }} -config Release --shallow -branch ${{ env.SKIA_BRANCH }} $ARCH_ARG
   
+      - name: Set archive name
+        id: archive
+        shell: bash
+        run: |
+          if [ -n "${{ matrix.arch }}" ]; then
+            echo "name=skia-build-${{ matrix.platform }}-${{ matrix.arch }}-${{ matrix.variant }}" >> $GITHUB_OUTPUT
+          else
+            echo "name=skia-build-${{ matrix.platform }}-${{ matrix.variant }}" >> $GITHUB_OUTPUT
+          fi
+
       - name: Create dummy files for test mode
         if: ${{ inputs.test_mode }}
         run: |
@@ -114,16 +146,16 @@ jobs:
         shell: bash
         run: |
           if [ "${{ runner.os }}" == "Windows" ]; then
-            7z a -tzip skia-build-${{ matrix.platform }}-${{ matrix.variant }}.zip build/include build/${{ matrix.platform }}-${{ matrix.variant }}
+            7z a -tzip ${{ steps.archive.outputs.name }}.zip build/include build/${{ matrix.platform }}-${{ matrix.variant }}
           else
-            zip -r skia-build-${{ matrix.platform }}-${{ matrix.variant }}.zip build/include build/${{ matrix.platform }}-${{ matrix.variant }}
+            zip -r ${{ steps.archive.outputs.name }}.zip build/include build/${{ matrix.platform }}-${{ matrix.variant }}
           fi
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: skia-build-${{ matrix.platform }}-${{ matrix.variant }}
-          path: skia-build-${{ matrix.platform }}-${{ matrix.variant }}.zip
+          name: ${{ steps.archive.outputs.name }}
+          path: ${{ steps.archive.outputs.name }}.zip
 
       - name: Set SKIA_BRANCH output
         run: echo "skia_branch=${{ env.SKIA_BRANCH }}" >> $GITHUB_OUTPUT
@@ -147,8 +179,10 @@ jobs:
           files: |
             ./skia-build-wasm-cpu/skia-build-wasm-cpu.zip
             ./skia-build-wasm-gpu/skia-build-wasm-gpu.zip
-            ./skia-build-linux-cpu/skia-build-linux-cpu.zip
-            ./skia-build-linux-gpu/skia-build-linux-gpu.zip
+            ./skia-build-linux-x64-cpu/skia-build-linux-x64-cpu.zip
+            ./skia-build-linux-x64-gpu/skia-build-linux-x64-gpu.zip
+            ./skia-build-linux-arm64-cpu/skia-build-linux-arm64-cpu.zip
+            ./skia-build-linux-arm64-gpu/skia-build-linux-arm64-gpu.zip
             ./skia-build-ios-cpu/skia-build-ios-cpu.zip
             ./skia-build-ios-gpu/skia-build-ios-gpu.zip
             ./skia-build-win-cpu/skia-build-win-cpu.zip

--- a/patches/dawn-x11-wayland-support.patch
+++ b/patches/dawn-x11-wayland-support.patch
@@ -1,0 +1,69 @@
+diff --git a/third_party/dawn/BUILD.gn b/third_party/dawn/BUILD.gn
+index e920f03..3779884 100644
+--- a/third_party/dawn/BUILD.gn
++++ b/third_party/dawn/BUILD.gn
+@@ -281,6 +281,16 @@ action("dawn_cmake") {
+   } else {
+     args += [ "--dawn_enable_vulkan=false" ]
+   }
++  if (dawn_use_x11) {
++    args += [ "--dawn_use_x11=true" ]
++  } else {
++    args += [ "--dawn_use_x11=false" ]
++  }
++  if (dawn_use_wayland) {
++    args += [ "--dawn_use_wayland=true" ]
++  } else {
++    args += [ "--dawn_use_wayland=false" ]
++  }
+ 
+   args += sanitizer_args
+ }
+diff --git a/third_party/dawn/args.gni b/third_party/dawn/args.gni
+index b2c2e70..9f9d50a 100644
+--- a/third_party/dawn/args.gni
++++ b/third_party/dawn/args.gni
+@@ -9,4 +9,6 @@ declare_args() {
+   dawn_enable_opengles = false
+   dawn_enable_metal = is_mac || is_ios
+   dawn_enable_vulkan = is_linux || is_android
++  dawn_use_x11 = is_linux
++  dawn_use_wayland = false
+ }
+diff --git a/third_party/dawn/build_dawn.py b/third_party/dawn/build_dawn.py
+index e23889e..574de99 100644
+--- a/third_party/dawn/build_dawn.py
++++ b/third_party/dawn/build_dawn.py
+@@ -54,6 +54,10 @@ def main():
+       "--dawn_enable_metal", default="false", help="Enable Metal backend.")
+   parser.add_argument(
+       "--dawn_enable_vulkan", default="false", help="Enable Vulkan backend.")
++  parser.add_argument(
++      "--dawn_use_x11", default="false", help="Enable X11 surface support.")
++  parser.add_argument(
++      "--dawn_use_wayland", default="false", help="Enable Wayland surface support.")
+   args = parser.parse_args()
+ 
+   cmake_exe = shutil.which("cmake")
+@@ -107,6 +111,8 @@ def main():
+       f"-DDAWN_ENABLE_OPENGLES={gn_bool_to_cmake(args.dawn_enable_opengles)}",
+       f"-DDAWN_ENABLE_METAL={gn_bool_to_cmake(args.dawn_enable_metal)}",
+       f"-DDAWN_ENABLE_VULKAN={gn_bool_to_cmake(args.dawn_enable_vulkan)}",
++      f"-DDAWN_USE_X11={gn_bool_to_cmake(args.dawn_use_x11)}",
++      f"-DDAWN_USE_WAYLAND={gn_bool_to_cmake(args.dawn_use_wayland)}",
+   ]
+   configure_cmd += get_third_party_locations()
+ 
+diff --git a/third_party/dawn/cmake_utils.py b/third_party/dawn/cmake_utils.py
+index ed4c89d..abe5775 100644
+--- a/third_party/dawn/cmake_utils.py
++++ b/third_party/dawn/cmake_utils.py
+@@ -403,7 +403,7 @@ def get_third_party_locations():
+     "-DTINT_BUILD_BENCHMARKS=OFF",
+     "-DTINT_BUILD_IR_BINARY=OFF",
+     "-DTINT_BUILD_TESTS=OFF",
+-    "-DDAWN_USE_X11=OFF",
++    # Note: DAWN_USE_X11 is now passed from build_dawn.py based on dawn_use_x11 GN arg
+ 
+     # Explicitly mark third_party deps as not here to make debugging easier
+     "-DDAWN_EMDAWNWEBGPU_DIR=NOT_SYNCED_BY_SKIA",


### PR DESCRIPTION
- Add ARM64 Linux builds to GitHub Actions workflow (ubuntu-24.04-arm runners)
- Include architecture in artifact names for Linux (x64/arm64)
- Add patches directory for post-sync modifications to Skia
- Add dawn-x11-wayland-support.patch to enable X11/Wayland surface support
- Add apply_patches() method to build-skia.py to apply patches after sync

The Dawn patch adds:
- dawn_use_x11 GN arg (defaults to true on Linux)
- dawn_use_wayland GN arg (defaults to false)
- Corresponding CLI args and CMake flags in build_dawn.py
- Removes hardcoded DAWN_USE_X11=OFF from cmake_utils.py

This enables WebGPU surfaces on Linux X11 (and optionally Wayland).