### PR TITLE
Tighten release workflow controls

### DIFF
--- a/.github/workflows/build-skia.yml
+++ b/.github/workflows/build-skia.yml
@@ -26,7 +26,7 @@ on:
         default: false
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ inputs.skia_branch || 'chrome/m144' }}-${{ inputs.platforms || 'all' }}-${{ inputs.skip_release && 'skip-release' || 'release' }}
   cancel-in-progress: true
 
 jobs:
@@ -396,6 +396,8 @@ jobs:
     if: ${{ !inputs.skip_release && inputs.platforms == 'all' }}
     needs: [build-skia, create-xcframework]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Download artifacts
         uses: actions/download-artifact@v4


### PR DESCRIPTION
This is a small workflow-only change that came out of testing full release builds in my fork.

Two things showed up:

- targeted validation runs can cancel a full release run, because concurrency is only keyed by workflow and ref
- the release job needs explicit write access when repository defaults leave `GITHUB_TOKEN` read-only

The concurrency group now includes the workflow inputs that affect what is being built. A duplicate run with the same inputs still cancels the older one, but a `platforms=win` test run no longer cancels a full `platforms=all` release run.

The release permission is scoped to the `create-release` job.