### PR TITLE
Keep D3D enabled for Skia m149 Windows Release

### DIFF
--- a/build-skia.py
+++ b/build-skia.py
@@ -223,6 +223,7 @@ PLATFORM_GN_ARGS = {
 
     "win": """
     skia_use_dawn = true
+    # Keep Direct3D enabled; the m149 build patch handles the Release-only issue.
     skia_use_direct3d = true
     is_trivial_abi = false
     """,

--- a/patches/fix_m149_d3d_backend_surface.patch
+++ b/patches/fix_m149_d3d_backend_surface.patch
@@ -1,0 +1,36 @@
+diff --git a/src/gpu/ganesh/d3d/GrD3DBackendSurface.cpp b/src/gpu/ganesh/d3d/GrD3DBackendSurface.cpp
+index 8d20c4fbda..e4d94b0c76 100644
+--- a/src/gpu/ganesh/d3d/GrD3DBackendSurface.cpp
++++ b/src/gpu/ganesh/d3d/GrD3DBackendSurface.cpp
+@@ -39,7 +39,6 @@ private:
+ 
+     GrColorFormatDesc desc() const override { return GrDxgiFormatDesc(fFormat); }
+ 
+-#if defined(GPU_TEST_UTILS)
+     bool equal(const GrBackendFormatData* that) const override {
+         SkASSERT(!that || that->type() == GrBackendApi::kDirect3D);
+         if (auto otherD3D = static_cast<const GrD3DBackendFormatData*>(that)) {
+@@ -47,7 +46,6 @@ private:
+         }
+         return false;
+     }
+-#endif
+ 
+     std::string toString() const override {
+ #if defined(SK_DEBUG) || defined(GPU_TEST_UTILS)
+@@ -114,6 +112,7 @@ private:
+ 
+     bool isProtected() const override { return false; }
+ 
++#if defined(GPU_TEST_UTILS)
+     bool equal(const GrBackendTextureData* that) const override {
+         SkASSERT(!that || that->type() == GrBackendApi::kDirect3D);
+ #if defined(GPU_TEST_UTILS)
+@@ -123,6 +122,7 @@ private:
+ #endif
+         return false;
+     }
++#endif
+ 
+     bool isSameTexture(const GrBackendTextureData* that) const override {
+         SkASSERT(!that || that->type() == GrBackendApi::kDirect3D);


### PR DESCRIPTION
This is a narrow alternative to the D3D workaround in #7.

When building `chrome/m149`, Windows Debug completed but Windows Release failed in Skia's D3D backend source. #7 avoids that by disabling Direct3D for now. This keeps `skia_use_direct3d = true` and applies a small source patch through the existing patch mechanism.

The failure is in `GrD3DBackendSurface.cpp`: the `equal` overrides do not line up with the `GPU_TEST_UTILS` guards used by the base classes on this branch.

Tested in a fork against `chrome/m149`; the Windows Release job and full release matrix completed. If disabling D3D until Skia fixes this upstream is preferred, this can just be closed.