### PR TITLE
Fix arm64e stripping in xcframework workflows

### DIFF
--- a/.github/workflows/build-skia.yml
+++ b/.github/workflows/build-skia.yml
@@ -330,14 +330,12 @@ jobs:
             local lib="$1"
             if lipo -info "$lib" 2>/dev/null | grep -q "arm64e"; then
               echo "Stripping arm64e from $lib"
-              # Get all architectures except arm64e
-              archs=$(lipo -info "$lib" | sed 's/.*: //' | tr ' ' '\n' | grep -v arm64e | tr '\n' ' ')
-              lipo "$lib" -extract $archs -output "${lib}.tmp"
+              lipo "$lib" -remove arm64e -output "${lib}.tmp"
               mv "${lib}.tmp" "$lib"
             fi
           }
 
-          for lib in $(find build -name "libSkia.a"); do
+          find build -name "libSkia.a" -print0 | while IFS= read -r -d '' lib; do
             strip_arm64e "$lib"
           done
 

--- a/.github/workflows/create-xcframework.yml
+++ b/.github/workflows/create-xcframework.yml
@@ -46,14 +46,12 @@ jobs:
             local lib="$1"
             if lipo -info "$lib" 2>/dev/null | grep -q "arm64e"; then
               echo "Stripping arm64e from $lib"
-              # Get all architectures except arm64e
-              archs=$(lipo -info "$lib" | sed 's/.*: //' | tr ' ' '\n' | grep -v arm64e | tr '\n' ' ')
-              lipo "$lib" -extract $archs -output "${lib}.tmp"
+              lipo "$lib" -remove arm64e -output "${lib}.tmp"
               mv "${lib}.tmp" "$lib"
             fi
           }
 
-          for lib in $(find build -name "libSkia.a"); do
+          find build -name "libSkia.a" -print0 | while IFS= read -r -d '' lib; do
             strip_arm64e "$lib"
           done
 


### PR DESCRIPTION
The current shell builds a list of architectures and passes it to `lipo -extract`. Since the goal is only to remove `arm64e`, `lipo -remove arm64e` is simpler and preserves the remaining slices directly.

This also changes the `find` loop to use `-print0`, so paths are passed through safely.