### PR TITLE
Add Windows /MD build variant and ANGLE support

### DIFF
--- a/.github/workflows/build-skia.yml
+++ b/.github/workflows/build-skia.yml
@@ -80,6 +80,19 @@ jobs:
             variant: gpu
             arch: x64
             config: Debug
+          # Windows dynamic CRT (/MD) variants
+          - os: windows-2022
+            platform: win
+            variant: gpu
+            arch: x64
+            config: Release
+            crt: MD
+          - os: windows-2022
+            platform: win
+            variant: gpu
+            arch: x64
+            config: Debug
+            crt: MD
           - os: ubuntu-latest
             platform: linux
             variant: gpu
@@ -246,8 +259,12 @@ jobs:
           if [ -n "${{ matrix.target }}" ]; then
             TARGET_ARG="-target ${{ matrix.target }}"
           fi
+          CRT_ARG=""
+          if [ -n "${{ matrix.crt }}" ]; then
+            CRT_ARG="-crt ${{ matrix.crt }}"
+          fi
           CONFIG="${{ matrix.config || 'Release' }}"
-          python3 build-skia.py ${{ matrix.platform }} -variant ${{ matrix.variant }} -config $CONFIG --shallow -branch ${{ env.SKIA_BRANCH }} $ARCH_ARG $TARGET_ARG
+          python3 build-skia.py ${{ matrix.platform }} -variant ${{ matrix.variant }} -config $CONFIG --shallow -branch ${{ env.SKIA_BRANCH }} $ARCH_ARG $TARGET_ARG $CRT_ARG
 
       - name: Set archive name
         if: steps.check.outputs.should_build == 'true'
@@ -268,18 +285,24 @@ jobs:
             ARCH_SAFE=$(echo "${{ matrix.arch }}" | tr ',' '-')
             NAME="${NAME}-${ARCH_SAFE}"
           fi
-          NAME="${NAME}-${{ matrix.variant }}-${CONFIG_LOWER}"
+          # Windows /MD builds get a -md suffix on the variant (dir and archive name)
+          VARIANT_SUFFIX="${{ matrix.variant }}"
+          if [ "${{ matrix.crt }}" = "MD" ]; then
+            VARIANT_SUFFIX="${VARIANT_SUFFIX}-md"
+          fi
+          NAME="${NAME}-${VARIANT_SUFFIX}-${CONFIG_LOWER}"
           echo "name=${NAME}" >> "$GITHUB_OUTPUT"
+          echo "libdir=build/${{ matrix.platform }}-${VARIANT_SUFFIX}" >> "$GITHUB_OUTPUT"
 
       - name: Create dummy files for test mode
         if: steps.check.outputs.should_build == 'true' && inputs.test_mode
         shell: bash
         run: |
           mkdir -p build/include
-          mkdir -p build/${{ matrix.platform }}-${{ matrix.variant }}
+          mkdir -p ${{ steps.archive.outputs.libdir }}
           echo "Test file" > build/include/test.h
-          echo "Test lib" > build/${{ matrix.platform }}-${{ matrix.variant }}/test.lib
-          echo "GN args summary" > build/${{ matrix.platform }}-${{ matrix.variant }}/gn_args.txt
+          echo "Test lib" > ${{ steps.archive.outputs.libdir }}/test.lib
+          echo "GN args summary" > ${{ steps.archive.outputs.libdir }}/gn_args.txt
 
       - name: Package binaries
         if: steps.check.outputs.should_build == 'true'
@@ -291,9 +314,9 @@ jobs:
             SHARE_DIR="build/share"
           fi
           if [ "${{ runner.os }}" == "Windows" ]; then
-            7z a -tzip ${{ steps.archive.outputs.name }}.zip build/include $SHARE_DIR build/${{ matrix.platform }}-${{ matrix.variant }}
+            7z a -tzip ${{ steps.archive.outputs.name }}.zip build/include $SHARE_DIR ${{ steps.archive.outputs.libdir }}
           else
-            zip -r ${{ steps.archive.outputs.name }}.zip build/include $SHARE_DIR build/${{ matrix.platform }}-${{ matrix.variant }}
+            zip -r ${{ steps.archive.outputs.name }}.zip build/include $SHARE_DIR ${{ steps.archive.outputs.libdir }}
           fi
 
       - name: Upload artifact
@@ -445,6 +468,8 @@ jobs:
             ./skia-build-visionos-simulator-arm64-gpu-release/skia-build-visionos-simulator-arm64-gpu-release.zip
             ./skia-build-win-x64-gpu-release/skia-build-win-x64-gpu-release.zip
             ./skia-build-win-x64-gpu-debug/skia-build-win-x64-gpu-debug.zip
+            ./skia-build-win-x64-gpu-md-release/skia-build-win-x64-gpu-md-release.zip
+            ./skia-build-win-x64-gpu-md-debug/skia-build-win-x64-gpu-md-debug.zip
             ./skia-build-linux-x64-gpu-release/skia-build-linux-x64-gpu-release.zip
             ./skia-build-wasm-wasm32-gpu-release/skia-build-wasm-wasm32-gpu-release.zip
             ./Skia.xcframework/Skia.xcframework.zip

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ example/.cache
 .vs
 example/build-*
 .claude/
+*.pyc

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,7 @@ python3 build-skia.py <platform> -config Debug    # Debug build (default: Releas
 python3 build-skia.py <platform> -branch chrome/m130  # Specific Skia branch
 python3 build-skia.py <platform> --shallow        # Shallow clone
 python3 build-skia.py <platform> -archs x86_64,arm64  # Specific architectures
+python3 build-skia.py win -crt MD                 # Windows dynamic CRT (/MD; default MT)
 
 # Windows (use py -3 or the build-win.sh helper)
 py -3 build-skia.py win -config Release -branch chrome/m130
@@ -62,7 +63,8 @@ build/
 ├── mac/lib/           # macOS libraries
 ├── ios/lib/           # iOS libraries (per-arch)
 ├── visionos/lib/      # visionOS libraries (arm64)
-├── win/lib/           # Windows libraries
+├── win-gpu/lib/       # Windows libraries (/MT static CRT; incl. ANGLE DLLs + import libs)
+├── win-gpu-md/lib/    # Windows libraries (/MD dynamic CRT, built with -crt MD)
 ├── linux/lib/         # Linux libraries
 ├── wasm/lib/          # WASM libraries
 └── xcframework/       # XCFramework output
@@ -72,6 +74,8 @@ build/
 - `USE_LIBGRAPHEME` constant (line 81) toggles between libgrapheme and ICU for Unicode
 - `MAC_MIN_VERSION` / `IOS_MIN_VERSION` set deployment targets
 - `EXCLUDE_DEPS` lists Skia dependencies to skip during sync
+- `-crt {MT,MD}` selects the Windows CRT linkage (default MT). MD outputs to `win-gpu-md/` dirs and CI publishes them as `skia-build-win-x64-gpu-md-*.zip`. `patch_dawn_crt_runtime()` rewrites Skia's `third_party/dawn/cmake_utils.py` (MultiThreaded vs MultiThreadedDLL) to match, bidirectionally, since the checkout is shared between MT/MD builds
+- Windows GPU builds enable ANGLE (`skia_use_angle=true`, except arm64 where GL is off). `libEGL.dll`/`libGLESv2.dll` + import libs are copied next to the Skia libs; ANGLE headers are packaged to `build/include/angle/`
 
 ## visionOS Support
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,20 @@ LLVM should be installed in `C:\Program Files\LLVM\`
 py -3 build-skia.py -config Release -branch chrome/m129 win
 ```
 
+### CRT linkage (/MT vs /MD)
+
+By default Windows libraries are built with the static CRT (`/MT`, `/MTd` for Debug). Pass `-crt MD` to build against the dynamic CRT (`/MD`, `/MDd` for Debug) instead — this also switches Dawn's CMake build to `MultiThreadedDLL`. MD builds are output to `build/win-gpu-md/lib/` so they don't collide with the default MT output in `build/win-gpu/lib/`.
+
+```bash
+py -3 build-skia.py -config Release -branch chrome/m129 -crt MD win
+```
+
+In CI, MD builds are published as separate zips: `skia-build-win-x64-gpu-md-release.zip` and `skia-build-win-x64-gpu-md-debug.zip` (the existing MT artifact names are unchanged).
+
+### ANGLE
+
+Windows GPU builds enable ANGLE (`skia_use_angle=true`). The Windows packages include `libEGL.dll`/`libGLESv2.dll` and their import libs (`libEGL.dll.lib`/`libGLESv2.dll.lib`) alongside the Skia libraries, plus the ANGLE headers (EGL, GLES2/3, KHR) under `include/angle/` — add that directory to your include paths to use `<EGL/egl.h>` etc. The ANGLE DLLs are self-contained, so the same DLLs work with both MT and MD packages.
+
 ## CI / GitHub Actions
 
 The repository includes a GitHub Actions workflow (`.github/workflows/build-skia.yml`) that builds all platforms in parallel and creates releases tagged with the Skia branch name.

--- a/build-skia.py
+++ b/build-skia.py
@@ -127,8 +127,11 @@ GPU_LIBS = {
     "linux": ["libdawn_combined.a"],
 }
 
-# ANGLE shared libraries (Windows gpu variant, GL-capable archs only)
-ANGLE_NINJA_TARGETS = ["libEGL", "libGLESv2"]
+# ANGLE shared libraries (Windows gpu variant, GL-capable archs only).
+# angle_libs is a group appended to Skia's BUILD.gn by patch_angle_build_gn() —
+# Skia only references //third_party/angle2 from test tools, so without it GN
+# never generates the libEGL/libGLESv2 targets in official builds.
+ANGLE_NINJA_TARGETS = ["angle_libs"]
 ANGLE_FILES_WIN = ["libEGL.dll", "libEGL.dll.lib", "libGLESv2.dll", "libGLESv2.dll.lib"]
 
 # Directories to package
@@ -959,6 +962,35 @@ class SkiaBuildScript:
                     shutil.copy2(src_file, dest_file)
         colored_print(f"Packaged ANGLE headers to {dest_root}", Colors.OKGREEN)
 
+    def patch_angle_build_gn(self):
+        """Expose ANGLE libraries as a top-level GN target.
+
+        Skia's BUILD.gn only references //third_party/angle2 from test/tool
+        targets, which don't exist in official builds — so GN never loads the
+        ANGLE build files and ninja has no libEGL/libGLESv2 targets. Appending
+        a group makes GN generate them. Idempotent; the checkout is reset with
+        git reset --hard on every run, so the append is re-applied each time."""
+        if not any(self.win_angle_enabled(arch) for arch in self.archs):
+            return
+        build_gn = SKIA_SRC_DIR / "BUILD.gn"
+        if not build_gn.exists():
+            colored_print(f"Warning: {build_gn} not found; cannot enable ANGLE targets", Colors.WARNING)
+            return
+        content = build_gn.read_text()
+        if 'group("angle_libs")' in content:
+            return
+        content += '''
+# Added by skia-builder: expose ANGLE libraries as a top-level target so they
+# are generated even when Skia's tools (the only in-tree consumers) are off.
+if (skia_use_angle) {
+  group("angle_libs") {
+    deps = [ "//third_party/angle2" ]
+  }
+}
+'''
+        build_gn.write_text(content)
+        colored_print("Appended angle_libs group to Skia BUILD.gn", Colors.OKGREEN)
+
     def patch_dawn_crt_runtime(self):
         """Set Dawn's CMake CRT flags to match -crt.
 
@@ -1305,6 +1337,7 @@ class SkiaBuildScript:
         self.sync_deps()
         self.apply_patches()
         self.patch_dawn_crt_runtime()
+        self.patch_angle_build_gn()
 
         if "universal" in self.archs or self.xcframework:
             self.archs = ["x86_64", "arm64"]

--- a/build-skia.py
+++ b/build-skia.py
@@ -38,6 +38,7 @@ SOFTWARE.
 
 import argparse
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -125,6 +126,10 @@ GPU_LIBS = {
     "wasm": [],  # WASM uses browser WebGPU
     "linux": ["libdawn_combined.a"],
 }
+
+# ANGLE shared libraries (Windows gpu variant, GL-capable archs only)
+ANGLE_NINJA_TARGETS = ["libEGL", "libGLESv2"]
+ANGLE_FILES_WIN = ["libEGL.dll", "libEGL.dll.lib", "libGLESv2.dll", "libGLESv2.dll.lib"]
 
 # Directories to package
 PACKAGE_DIRS = [
@@ -392,6 +397,7 @@ class SkiaBuildScript:
         self.branch = None
         self.variant = "gpu"
         self.target = "all"  # device, simulator, or all
+        self.crt = "MT"  # Windows CRT linkage: MT (static) or MD (dynamic)
 
     def parse_arguments(self):
         parser = argparse.ArgumentParser(description="Build Skia for macOS, iOS, visionOS, Windows, Linux and WebAssembly")
@@ -404,6 +410,8 @@ class SkiaBuildScript:
                            help="Build variant: cpu (no GPU) or gpu (with Graphite/Dawn)")
         parser.add_argument("-target", choices=["device", "simulator", "all"], default="all",
                            help="Build target for iOS/visionOS: device, simulator, or all")
+        parser.add_argument("-crt", choices=["MT", "MD"], default="MT",
+                           help="Windows CRT linkage: MT (static, default) or MD (dynamic). No effect on other platforms")
         parser.add_argument("--shallow", action="store_true", help="Perform a shallow clone of the Skia repository")
         parser.add_argument("--zip-all", action="store_true",
                            help="Create a zip archive containing all platform libraries")
@@ -427,6 +435,10 @@ class SkiaBuildScript:
         self.branch = args.branch
         self.variant = args.variant
         self.target = args.target
+        self.crt = args.crt
+        if self.crt == "MD" and self.platform != "win":
+            colored_print("Warning: -crt MD only affects Windows; ignoring.", Colors.WARNING)
+            self.crt = "MT"
         self.shallow_clone = args.shallow
         self.create_zip_all = args.zip_all
         self.strip_arm64e = args.strip_arm64e
@@ -460,9 +472,22 @@ class SkiaBuildScript:
                 colored_print(f"Invalid architecture for {self.platform}: {arch}", Colors.FAIL)
                 sys.exit(1)
 
+    def build_tmp_dir(self, arch):
+        """Get the intermediate ninja/GN output directory for an arch."""
+        name = f"{self.platform}_{self.config}_{arch}_{self.variant}"
+        if self.platform == "win" and self.crt == "MD":
+            name += "_md"
+        return TMP_DIR / name
+
+    def win_angle_enabled(self, arch):
+        """ANGLE is built on Windows GPU builds, except arm64 (no GL there)."""
+        return self.platform == "win" and self.variant == "gpu" and arch != "arm64"
+
     def get_lib_dir(self, platform):
         """Get the library directory for a platform, including variant suffix."""
         variant_suffix = f"-{self.variant}"
+        if platform == "win" and self.crt == "MD":
+            variant_suffix += "-md"
         if platform == "mac":
             return BASE_DIR / f"mac{variant_suffix}" / "lib"
         elif platform == "ios":
@@ -487,7 +512,7 @@ class SkiaBuildScript:
         subprocess.run([sys.executable, "tools/git-sync-deps"], check=True)
 
     def generate_gn_args(self, arch: str):
-        output_dir = TMP_DIR / f"{self.platform}_{self.config}_{arch}_{self.variant}"
+        output_dir = self.build_tmp_dir(arch)
         gn_args = BASIC_GN_ARGS
 
         # Use CPU or GPU platform-specific args based on variant
@@ -579,7 +604,11 @@ class SkiaBuildScript:
     ]
 '''
         elif self.platform == "win":
-            gn_args += f"extra_cflags = [\"{'/MTd' if self.config == 'Debug' else '/MT'}\"]\n"
+            if self.crt == "MD":
+                crt_flag = "/MDd" if self.config == "Debug" else "/MD"
+            else:
+                crt_flag = "/MTd" if self.config == "Debug" else "/MT"
+            gn_args += f"extra_cflags = [\"{crt_flag}\"]\n"
             # Map architecture names to GN target_cpu values
             if arch == "Win32":
                 gn_args += "target_cpu = \"x86\"\n"
@@ -589,6 +618,9 @@ class SkiaBuildScript:
                 gn_args += "skia_use_gl = false\n"
             else:  # x64
                 gn_args += "target_cpu = \"x64\"\n"
+            # ANGLE requires GL, so it's excluded on arm64 (skia_use_gl = false above)
+            if self.win_angle_enabled(arch):
+                gn_args += "skia_use_angle = true\n"
             # Find Clang installation - prefer standalone LLVM, fallback to VS bundled
             clang_paths = [
                 "C:\\Program Files\\LLVM",
@@ -616,7 +648,7 @@ class SkiaBuildScript:
         subprocess.run(["./bin/gn", "gen", str(output_dir), f"--args={gn_args}"], check=True)
 
     def build_skia(self, arch: str):
-        output_dir = TMP_DIR / f"{self.platform}_{self.config}_{arch}_{self.variant}"
+        output_dir = self.build_tmp_dir(arch)
         
         # Get the list of libraries for the current platform
         libs_to_build = LIBS[self.platform]
@@ -628,7 +660,11 @@ class SkiaBuildScript:
         # so pass bare GN target names to ninja and rename at move_libs time.
         elif self.platform == "wasm":
             libs_to_build = [lib[3:-2] if lib.startswith('lib') and lib.endswith('.a') else lib for lib in libs_to_build]
-        
+
+        # ANGLE target names are already bare, so add them after the .lib stripping
+        if self.win_angle_enabled(arch):
+            libs_to_build = libs_to_build + ANGLE_NINJA_TARGETS
+
         # Construct the ninja command with all library targets
         ninja_command = ["ninja", "-C", str(output_dir)] + libs_to_build
 
@@ -643,7 +679,7 @@ class SkiaBuildScript:
             sys.exit(1)
 
     def move_libs(self, arch: str):
-        src_dir = TMP_DIR / f"{self.platform}_{self.config}_{arch}_{self.variant}"
+        src_dir = self.build_tmp_dir(arch)
         lib_dir = self.get_lib_dir(self.platform)
         if self.platform == "mac":
             dest_dir = lib_dir / self.config / (arch if arch != "universal" else "")
@@ -700,6 +736,16 @@ class SkiaBuildScript:
                         self.strip_arm64e_from_library(dest_file)
                 else:
                     colored_print(f"Warning: Dawn library {lib} not found", Colors.WARNING)
+
+        # Copy ANGLE shared libraries and import libs (Windows GPU variant)
+        if self.win_angle_enabled(arch):
+            for lib in ANGLE_FILES_WIN:
+                src_file = src_dir / lib
+                if src_file.exists():
+                    shutil.copy2(str(src_file), str(dest_dir / lib))
+                    colored_print(f"Copied {lib} (ANGLE) to {dest_dir}", Colors.OKGREEN)
+                else:
+                    colored_print(f"Warning: ANGLE file {lib} not found in {src_dir}", Colors.WARNING)
 
     def strip_arm64e_from_library(self, lib_path):
         """Strip arm64e slice from a fat library, keeping only arm64."""
@@ -894,6 +940,48 @@ class SkiaBuildScript:
         shutil.copy2(icu_data_src, icu_data_dest)
         colored_print(f"Copied ICU data file to {icu_data_dest}", Colors.OKGREEN)
 
+    def package_angle_headers(self, dest_dir):
+        """Copy ANGLE public headers (EGL, GLES2/3, KHR, ...) to <dest_dir>/angle.
+
+        The subtree is preserved so <EGL/egl.h> can resolve its sibling
+        <KHR/khrplatform.h> include; consumers add include/angle to their paths."""
+        src_root = SKIA_SRC_DIR / "third_party" / "externals" / "angle2" / "include"
+        if not src_root.exists():
+            colored_print(f"Warning: ANGLE include dir not found at {src_root}", Colors.WARNING)
+            return
+        dest_root = dest_dir / "angle"
+        for root, dirs, files in os.walk(src_root):
+            for file in files:
+                if file.endswith(('.h', '.inc')):
+                    src_file = Path(root) / file
+                    dest_file = dest_root / src_file.relative_to(src_root)
+                    dest_file.parent.mkdir(parents=True, exist_ok=True)
+                    shutil.copy2(src_file, dest_file)
+        colored_print(f"Packaged ANGLE headers to {dest_root}", Colors.OKGREEN)
+
+    def patch_dawn_crt_runtime(self):
+        """Set Dawn's CMake CRT flags to match -crt.
+
+        Skia hardcodes /MT (MultiThreaded) for Dawn's CMake build. The rewrite is
+        deterministic in both directions because the Skia checkout is shared
+        between MT and MD builds."""
+        if self.platform != "win" or self.variant != "gpu":
+            return
+        cmake_utils = SKIA_SRC_DIR / "third_party" / "dawn" / "cmake_utils.py"
+        if not cmake_utils.exists():
+            colored_print(f"Warning: {cmake_utils} not found; cannot set Dawn CRT", Colors.WARNING)
+            return
+        runtime = "MultiThreadedDLL" if self.crt == "MD" else "MultiThreaded"
+        absl = "OFF" if self.crt == "MD" else "ON"
+        content = cmake_utils.read_text()
+        new_content = re.sub(r'-DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded(?:DLL)?',
+                             f'-DCMAKE_MSVC_RUNTIME_LIBRARY={runtime}', content)
+        new_content = re.sub(r'-DABSL_MSVC_STATIC_RUNTIME=(?:ON|OFF)',
+                             f'-DABSL_MSVC_STATIC_RUNTIME={absl}', new_content)
+        if new_content != content:
+            cmake_utils.write_text(new_content)
+            colored_print(f"Dawn CMake CRT set to {runtime} (ABSL_MSVC_STATIC_RUNTIME={absl})", Colors.OKGREEN)
+
     def package_generated_dawn_headers(self, build_dir, dest_dir):
         """Copy generated Dawn headers from build output to package.
         Falls back to copying from existing macOS build if headers not found locally."""
@@ -1039,7 +1127,7 @@ class SkiaBuildScript:
 
     def cleanup(self):
         for arch in self.archs:
-            shutil.rmtree(TMP_DIR / f"{self.platform}_{self.config}_{arch}_{self.variant}", ignore_errors=True)
+            shutil.rmtree(self.build_tmp_dir(arch), ignore_errors=True)
         colored_print("Cleaned up temporary directories", Colors.OKBLUE)
 
     def setup_skia_repo(self):
@@ -1106,6 +1194,8 @@ class SkiaBuildScript:
         target_cpu = "{arch}"
         variant = "{self.variant}"
         """
+        if self.platform == "win":
+            gn_args += f'crt = "{self.crt}"\n'
         # Remove leading whitespace from each line while preserving structure
         lines = [line.strip() for line in gn_args.strip().splitlines()]
         return '\n'.join(line for line in lines if line)
@@ -1214,6 +1304,7 @@ class SkiaBuildScript:
 
         self.sync_deps()
         self.apply_patches()
+        self.patch_dawn_crt_runtime()
 
         if "universal" in self.archs or self.xcframework:
             self.archs = ["x86_64", "arm64"]
@@ -1245,12 +1336,14 @@ class SkiaBuildScript:
         else:
             self.package_headers(BASE_DIR / "include")
             self.package_icu_data(BASE_DIR / "share")
+            if any(self.win_angle_enabled(arch) for arch in self.archs):
+                self.package_angle_headers(BASE_DIR / "include")
 
         # Copy generated Dawn headers (for Graphite WebGPU backend)
         if self.variant == "gpu":
             # Use the first arch's build dir for generated headers (they're the same across archs)
             first_arch = self.archs[0]
-            build_dir = TMP_DIR / f"{self.platform}_{self.config}_{first_arch}_{self.variant}"
+            build_dir = self.build_tmp_dir(first_arch)
             self.package_generated_dawn_headers(build_dir, BASE_DIR / "include")
 
         self.write_gn_args_summary()


### PR DESCRIPTION
## Summary

- Adds a `-crt {MT,MD}` option to `build-skia.py` (default MT). MD builds compile with `/MD` (`/MDd` Debug), output to separate `build/win-gpu-md/` dirs, and rewrite Skia's `third_party/dawn/cmake_utils.py` (bidirectionally, since the checkout is shared) so Dawn's CMake build uses `MultiThreadedDLL` / `ABSL_MSVC_STATIC_RUNTIME=OFF` to match.
- Enables ANGLE on Windows GPU builds (`skia_use_angle=true`, x64/Win32 only — arm64 has no GL). Skia only references `//third_party/angle2` from test tools, which don't exist in official builds, so an `angle_libs` group is appended to Skia's `BUILD.gn` to make GN generate the targets. `libEGL.dll`/`libGLESv2.dll` + import libs are packaged next to the Skia libs, and ANGLE headers (EGL/GLES2/GLES3/KHR) land in `include/angle/`.
- CI: two new matrix jobs (win x64 gpu Release/Debug, `crt: MD`) publishing `skia-build-win-x64-gpu-md-release.zip` / `-md-debug.zip`; both added to the release job. Existing MT artifact names are byte-identical. The archive step now emits the lib dir as a step output instead of hardcoding `build/<platform>-<variant>` (no-op for existing entries).
- Each Windows artifact's `gn_args.txt` now records its CRT.

Known caveat (mirrors existing MT behavior): Dawn upstream builds Windows Debug as RelWithDebInfo, so Debug zips pair `/MTd`|`/MDd` Skia libs with `/MT`|`/MD` Dawn.

## Test plan

- [x] test_mode CI run: 4 win artifacts with correct names; MD zip packages `build/win-gpu-md/`, MT packages `build/win-gpu/`
- [x] Real win-only CI run ([29493908754](https://github.com/olilarkin/skia-builder/actions/runs/29493908754)): all 4 jobs green
- [x] Zip contents verified: Skia libs + `dawn_combined.lib` + ANGLE DLLs/import libs, `include/angle/**` headers, `gn_args.txt` records crt
- [x] CRT proven via `/DEFAULTLIB` directive scan — uniform in every lib: MT release `libcmt`, MD release `msvcrt`, MT debug `libcmtd`, MD debug `msvcrtd`; Dawn correctly `libcmt`/`msvcrt`
- [ ] First `platforms=all` release run after merge exercises the two new `files:` entries in create-release

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cc3FVRpJCVkLvyA4v8vVED