### PR TITLE
Pin & control Apple minimum OS deployment targets

### DIFF
--- a/.github/workflows/build-skia.yml
+++ b/.github/workflows/build-skia.yml
@@ -24,6 +24,21 @@ on:
         required: false
         type: boolean
         default: false
+      mac_min_version:
+        description: 'Minimum macOS deployment target (empty = script default)'
+        required: false
+        type: string
+        default: ''
+      ios_min_version:
+        description: 'Minimum iOS deployment target (empty = script default)'
+        required: false
+        type: string
+        default: ''
+      visionos_min_version:
+        description: 'Minimum visionOS deployment target (empty = script default)'
+        required: false
+        type: string
+        default: ''
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ inputs.skia_branch || 'chrome/m144' }}-${{ inputs.platforms || 'all' }}-${{ inputs.skip_release && 'skip-release' || 'release' }}
@@ -263,8 +278,18 @@ jobs:
           if [ -n "${{ matrix.crt }}" ]; then
             CRT_ARG="-crt ${{ matrix.crt }}"
           fi
+          MIN_VERSION_ARGS=""
+          if [ -n "${{ inputs.mac_min_version }}" ]; then
+            MIN_VERSION_ARGS="$MIN_VERSION_ARGS -mac-min-version ${{ inputs.mac_min_version }}"
+          fi
+          if [ -n "${{ inputs.ios_min_version }}" ]; then
+            MIN_VERSION_ARGS="$MIN_VERSION_ARGS -ios-min-version ${{ inputs.ios_min_version }}"
+          fi
+          if [ -n "${{ inputs.visionos_min_version }}" ]; then
+            MIN_VERSION_ARGS="$MIN_VERSION_ARGS -visionos-min-version ${{ inputs.visionos_min_version }}"
+          fi
           CONFIG="${{ matrix.config || 'Release' }}"
-          python3 build-skia.py ${{ matrix.platform }} -variant ${{ matrix.variant }} -config $CONFIG --shallow -branch ${{ env.SKIA_BRANCH }} $ARCH_ARG $TARGET_ARG $CRT_ARG
+          python3 build-skia.py ${{ matrix.platform }} -variant ${{ matrix.variant }} -config $CONFIG --shallow -branch ${{ env.SKIA_BRANCH }} $ARCH_ARG $TARGET_ARG $CRT_ARG $MIN_VERSION_ARGS
 
       - name: Set archive name
         if: steps.check.outputs.should_build == 'true'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,7 @@ python3 build-skia.py <platform> -branch chrome/m130  # Specific Skia branch
 python3 build-skia.py <platform> --shallow        # Shallow clone
 python3 build-skia.py <platform> -archs x86_64,arm64  # Specific architectures
 python3 build-skia.py win -crt MD                 # Windows dynamic CRT (/MD; default MT)
+python3 build-skia.py mac -mac-min-version 12.0   # Override macOS deployment target (also: -ios-min-version, -visionos-min-version)
 
 # Windows (use py -3 or the build-win.sh helper)
 py -3 build-skia.py win -config Release -branch chrome/m130
@@ -72,7 +73,7 @@ build/
 
 **Key configuration:**
 - `USE_LIBGRAPHEME` constant (line 81) toggles between libgrapheme and ICU for Unicode
-- `MAC_MIN_VERSION` / `IOS_MIN_VERSION` set deployment targets
+- `MAC_MIN_VERSION` / `IOS_MIN_VERSION` / `VISIONOS_MIN_VERSION` are the default deployment targets, overridable with `-mac-min-version` etc. They are applied to the GN build via `-target` flags and to Dawn's CMake sub-build via `MACOSX_DEPLOYMENT_TARGET` / `SKIA_IOS_MIN_VERSION` / `SKIA_VISIONOS_MIN_VERSION` env vars (the latter two read by code that `patches/apply_dawn_ios_visionos.py` injects) — Dawn otherwise inherits the build host's OS as its minimum (gh issue #13)
 - `EXCLUDE_DEPS` lists Skia dependencies to skip during sync
 - `-crt {MT,MD}` selects the Windows CRT linkage (default MT). MD outputs to `win-gpu-md/` dirs and CI publishes them as `skia-build-win-x64-gpu-md-*.zip`. `patch_dawn_crt_runtime()` rewrites Skia's `third_party/dawn/cmake_utils.py` (MultiThreaded vs MultiThreadedDLL) to match, bidirectionally, since the checkout is shared between MT/MD builds
 - Windows GPU builds enable ANGLE (`skia_use_angle=true`, except arm64 where GL is off). `libEGL.dll`/`libGLESv2.dll` + import libs are copied next to the Skia libs; ANGLE headers are packaged to `build/include/angle/`

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ ulimit -n 2048
 
 in order to increase the number of files that can be opened at once.
 
-Note: macOS builds target macOS 11+ (Big Sur). This is hardcoded in Skia's `gn/skia/BUILD.gn` via the `-target` compiler flag.
+Note: macOS builds target macOS 11+ (Big Sur) by default, applied via `-target` compiler flags and `MACOSX_DEPLOYMENT_TARGET` so that both the Skia libraries and the Dawn CMake sub-build are pinned. The minimum deployment targets are configurable with `-mac-min-version`, `-ios-min-version` and `-visionos-min-version` (e.g. `python3 build-skia.py mac -mac-min-version 12.0`).
 
 ### Build for macOS universal (arm64 & x86_64 intel)
 

--- a/build-skia.py
+++ b/build-skia.py
@@ -75,8 +75,8 @@ WASM_LIB_DIR = BASE_DIR / "wasm" / "lib"
 WIN_LIB_DIR = BASE_DIR / "win" / "lib"
 LINUX_LIB_DIR = BASE_DIR / "linux" / "lib"
 
-# Platform-specific constants
-MAC_MIN_VERSION = "10.15"
+# Default minimum OS versions (overridable with -mac-min-version etc.)
+MAC_MIN_VERSION = "11.0"  # Dawn requires macOS 11.0+ for C++ atomic wait/notify
 IOS_MIN_VERSION = "14.0"  # Dawn requires iOS 14.0+ for C++ atomic wait/notify
 VISIONOS_MIN_VERSION = "1.0"
 
@@ -310,14 +310,11 @@ PLATFORM_GN_ARGS_CPU = {
     extra_cflags_c = ["-Wno-error"]
     """,
 
-    "ios": f"""
+    # extra_cflags (target/sysroot/min version) are appended in generate_gn_args().
+    "ios": """
     skia_use_metal = false
     target_os = "ios"
     skia_ios_use_signing = false
-    extra_cflags = [
-        "-miphoneos-version-min={IOS_MIN_VERSION}",
-        "-I../../../src/skia/third_party/externals/expat/lib"
-    ]
     extra_cflags_c = ["-Wno-error"]
     """,
 
@@ -401,6 +398,9 @@ class SkiaBuildScript:
         self.variant = "gpu"
         self.target = "all"  # device, simulator, or all
         self.crt = "MT"  # Windows CRT linkage: MT (static) or MD (dynamic)
+        self.mac_min_version = MAC_MIN_VERSION
+        self.ios_min_version = IOS_MIN_VERSION
+        self.visionos_min_version = VISIONOS_MIN_VERSION
 
     def parse_arguments(self):
         parser = argparse.ArgumentParser(description="Build Skia for macOS, iOS, visionOS, Windows, Linux and WebAssembly")
@@ -415,6 +415,12 @@ class SkiaBuildScript:
                            help="Build target for iOS/visionOS: device, simulator, or all")
         parser.add_argument("-crt", choices=["MT", "MD"], default="MT",
                            help="Windows CRT linkage: MT (static, default) or MD (dynamic). No effect on other platforms")
+        parser.add_argument("-mac-min-version", default=MAC_MIN_VERSION,
+                           help=f"Minimum macOS deployment target (default: {MAC_MIN_VERSION})")
+        parser.add_argument("-ios-min-version", default=IOS_MIN_VERSION,
+                           help=f"Minimum iOS deployment target (default: {IOS_MIN_VERSION})")
+        parser.add_argument("-visionos-min-version", default=VISIONOS_MIN_VERSION,
+                           help=f"Minimum visionOS deployment target (default: {VISIONOS_MIN_VERSION})")
         parser.add_argument("--shallow", action="store_true", help="Perform a shallow clone of the Skia repository")
         parser.add_argument("--zip-all", action="store_true",
                            help="Create a zip archive containing all platform libraries")
@@ -439,6 +445,9 @@ class SkiaBuildScript:
         self.variant = args.variant
         self.target = args.target
         self.crt = args.crt
+        self.mac_min_version = args.mac_min_version
+        self.ios_min_version = args.ios_min_version
+        self.visionos_min_version = args.visionos_min_version
         if self.crt == "MD" and self.platform != "win":
             colored_print("Warning: -crt MD only affects Windows; ignoring.", Colors.WARNING)
             self.crt = "MT"
@@ -534,7 +543,14 @@ class SkiaBuildScript:
             gn_args += "is_official_build = true\n"
 
         if self.platform == "mac":
-            gn_args += f"target_cpu = \"{arch}\""
+            gn_args += f'target_cpu = "{arch}"\n'
+            # Pin the deployment target explicitly. Skia's GN files pin their own
+            # macOS minimum, but Dawn and other sub-builds inherit the build
+            # host's OS without this (gh issue #13). extra_cflags come after
+            # Skia's own flags, so this -target wins.
+            gn_args += f'''extra_cflags = [ "-target", "{arch}-apple-macos{self.mac_min_version}" ]
+    extra_asmflags = [ "-target", "{arch}-apple-macos{self.mac_min_version}" ]
+'''
         elif self.platform == "ios":
             cpu = "arm64" if arch == "arm64" else "x64"
             gn_args += f'target_cpu = "{cpu}"\n'
@@ -555,7 +571,7 @@ class SkiaBuildScript:
                 sdk_path = sdk_result.stdout.strip()
                 colored_print(f"Using iOS Simulator SDK: {sdk_path}", Colors.OKBLUE)
                 gn_args += f'''extra_cflags = [
-        "-target", "{arch}-apple-ios{IOS_MIN_VERSION}-simulator",
+        "-target", "{arch}-apple-ios{self.ios_min_version}-simulator",
         "-isysroot", "{sdk_path}",
         "-I../../../src/skia/third_party/externals/expat/lib"
     ]
@@ -569,7 +585,7 @@ class SkiaBuildScript:
                 sdk_path = sdk_result.stdout.strip()
                 colored_print(f"Using iOS Device SDK: {sdk_path}", Colors.OKBLUE)
                 gn_args += f'''extra_cflags = [
-        "-target", "{arch}-apple-ios{IOS_MIN_VERSION}",
+        "-target", "{arch}-apple-ios{self.ios_min_version}",
         "-isysroot", "{sdk_path}",
         "-I../../../src/skia/third_party/externals/expat/lib"
     ]
@@ -597,12 +613,12 @@ class SkiaBuildScript:
             # Add extra_cflags and extra_asmflags with target and sysroot to override iOS defaults
             # extra_asmflags is needed for ICU data file (icudtl_dat.o) to get correct platform metadata
             gn_args += f'''extra_cflags = [
-        "-target", "arm64-apple-xros{VISIONOS_MIN_VERSION}{target_suffix}",
+        "-target", "arm64-apple-xros{self.visionos_min_version}{target_suffix}",
         "-isysroot", "{sdk_path}",
         "-I../../../src/skia/third_party/externals/expat/lib"
     ]
     extra_asmflags = [
-        "-target", "arm64-apple-xros{VISIONOS_MIN_VERSION}{target_suffix}",
+        "-target", "arm64-apple-xros{self.visionos_min_version}{target_suffix}",
         "-isysroot", "{sdk_path}"
     ]
 '''
@@ -1228,6 +1244,12 @@ if (skia_use_angle) {
         """
         if self.platform == "win":
             gn_args += f'crt = "{self.crt}"\n'
+        elif self.platform == "mac":
+            gn_args += f'min_os_version = "{self.mac_min_version}"\n'
+        elif self.platform == "ios":
+            gn_args += f'min_os_version = "{self.ios_min_version}"\n'
+        elif self.platform == "visionos":
+            gn_args += f'min_os_version = "{self.visionos_min_version}"\n'
         # Remove leading whitespace from each line while preserving structure
         lines = [line.strip() for line in gn_args.strip().splitlines()]
         return '\n'.join(line for line in lines if line)
@@ -1325,6 +1347,16 @@ if (skia_use_angle) {
 
     def run(self):
         self.parse_arguments()
+
+        # Pin Apple deployment targets for Dawn's CMake sub-build, which doesn't
+        # inherit GN's extra_cflags. CMake reads MACOSX_DEPLOYMENT_TARGET natively
+        # on the Darwin path; the SKIA_* vars are read by the get_ios_settings /
+        # get_visionos_settings helpers that patches/apply_dawn_ios_visionos.py
+        # adds to Skia's third_party/dawn/cmake_utils.py. See gh issue #13.
+        os.environ["MACOSX_DEPLOYMENT_TARGET"] = self.mac_min_version
+        os.environ["SKIA_IOS_MIN_VERSION"] = self.ios_min_version
+        os.environ["SKIA_VISIONOS_MIN_VERSION"] = self.visionos_min_version
+
         self.setup_depot_tools()
         self.setup_skia_repo()
         self.setup_gn_for_windows_arm64()

--- a/patches/apply_dawn_ios_visionos.py
+++ b/patches/apply_dawn_ios_visionos.py
@@ -191,8 +191,10 @@ def get_ios_settings(target_cpu, is_simulator=False):
     sys.exit(1)
 
   ios_cfgs.append(f"-DCMAKE_OSX_SYSROOT={sdk_path}")
-  # Dawn uses C++ atomic wait/notify_all which requires iOS 14.0+
-  ios_cfgs.append("-DCMAKE_OSX_DEPLOYMENT_TARGET=14.0")
+  # Dawn uses C++ atomic wait/notify_all which requires iOS 14.0+.
+  # build-skia.py exports SKIA_IOS_MIN_VERSION from its -ios-min-version flag.
+  min_version = os.environ.get("SKIA_IOS_MIN_VERSION", "14.0")
+  ios_cfgs.append(f"-DCMAKE_OSX_DEPLOYMENT_TARGET={min_version}")
 
   # Cross-compilation hints for pthreads (built-in on iOS)
   # CMake's FindThreads module can't run test programs when cross-compiling,
@@ -242,14 +244,16 @@ def get_visionos_settings(target_cpu, is_simulator=False):
     sys.exit(1)
 
   visionos_cfgs.append(f"-DCMAKE_OSX_SYSROOT={sdk_path}")
-  # visionOS minimum deployment target
-  visionos_cfgs.append("-DCMAKE_OSX_DEPLOYMENT_TARGET=1.0")
+  # visionOS minimum deployment target.
+  # build-skia.py exports SKIA_VISIONOS_MIN_VERSION from its -visionos-min-version flag.
+  min_version = os.environ.get("SKIA_VISIONOS_MIN_VERSION", "1.0")
+  visionos_cfgs.append(f"-DCMAKE_OSX_DEPLOYMENT_TARGET={min_version}")
   # Add target triple flags to ensure correct platform metadata in object files
   # This is critical - without it, object files get iOS platform metadata instead of visionOS
   # Include -w to suppress warnings (normally added elsewhere, but we're overriding FLAGS)
-  visionos_cfgs.append(f"-DCMAKE_C_FLAGS=-w -target arm64-apple-xros1.0{target_suffix}")
-  visionos_cfgs.append(f"-DCMAKE_CXX_FLAGS=-w -target arm64-apple-xros1.0{target_suffix}")
-  visionos_cfgs.append(f"-DCMAKE_ASM_FLAGS=-target arm64-apple-xros1.0{target_suffix}")
+  visionos_cfgs.append(f"-DCMAKE_C_FLAGS=-w -target arm64-apple-xros{min_version}{target_suffix}")
+  visionos_cfgs.append(f"-DCMAKE_CXX_FLAGS=-w -target arm64-apple-xros{min_version}{target_suffix}")
+  visionos_cfgs.append(f"-DCMAKE_ASM_FLAGS=-target arm64-apple-xros{min_version}{target_suffix}")
 
   # Cross-compilation hints for pthreads (built-in on visionOS)
   visionos_cfgs.append("-DCMAKE_CROSSCOMPILING=YES")


### PR DESCRIPTION
Fixes the macOS part of #13.

## Problem

`libdawn_combined.a` on macOS was stamped with whatever macOS version the CI runner happens to run (e.g. 15.0 on `macos-15`): `MAC_MIN_VERSION` was defined but never applied, and while Skia's own GN files pin their macOS minimum internally, Dawn's separate CMake sub-build has no default and inherits the build host's OS.

## Changes

- **Skia (GN)**: the mac branch of `generate_gn_args()` now passes `-target {arch}-apple-macos{min}` via `extra_cflags`/`extra_asmflags`, mirroring the iOS branch.
- **Dawn (CMake)**: `build-skia.py` exports `MACOSX_DEPLOYMENT_TARGET`, which CMake picks up natively on the Darwin path.
- **iOS/visionOS Dawn**: the deployment targets generated by `patches/apply_dawn_ios_visionos.py` (previously hardcoded 14.0 / 1.0) are now read from `SKIA_IOS_MIN_VERSION` / `SKIA_VISIONOS_MIN_VERSION` env vars at Dawn build time, so the flags below control them too.
- **New CLI flags**: `-mac-min-version` (default 11.0), `-ios-min-version` (default 14.0), `-visionos-min-version` (default 1.0), plus matching optional `workflow_dispatch` inputs.
- Default macOS minimum is 11.0 — matches the README's "macOS 11+" claim, Skia's internal GN pin, and Dawn's C++ atomic wait/notify requirement (10.15 was never viable for the GPU variant).
- Removed a dead CPU-variant iOS `extra_cflags` block that baked `IOS_MIN_VERSION` in at module import time (it was unconditionally overwritten later in `generate_gn_args()`).
- `gn_args.txt` summaries now record `min_os_version` for Apple platforms.

## Not addressed

The Linux glibc floor from #13 — that needs a pinned sysroot or an older build container (see the reporter's `portable-linux-x64` job), and is better tracked separately.

## Verification

- Patch script applied cleanly and idempotently against upstream `chrome/m149` Dawn files; patched output compiles.
- Mocked-`gn` test confirmed the generated args for mac/ios/visionos with defaults and overrides.
- CI mac build triggered from this branch to check `LC_BUILD_VERSION` minos on the produced libs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)